### PR TITLE
update gradle, spring boot and add actuator start so shutdown can be enabled in CI

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
+    ":disableRateLimiting",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(renovatebot)"
+  ],
+  "labels": ["dependencies", "bot"]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+env:
+  JAVA_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server -XX:+UseG1GC"
+  GRADLE_OPTS: "-Xms512m -Xmx6048m -Xss128m -XX:ReservedCodeCacheSize=512m -server -XX:+UseG1GC"
+  TERM: xterm-256color
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  JDK_CURRENT: 11
+
+##########################################################################
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+##########################################################################
+
+jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: cancel-previous-runs
+    steps:
+      - uses: actions/checkout@v2
+      #      - name: Setup tmate session
+      #        uses: mxschmitt/action-tmate@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+          distribution: 'temurin'
+      - name: Build
+        run: ./gradlew clean build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,3 +43,8 @@ jobs:
           distribution: 'temurin'
       - name: Build
         run: ./gradlew clean build
+      - name: Upload client build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: bootiful-cas-client
+          path: build/libs/bootiful-cas-client.jar

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencyManagement {
 
 jar {
     archiveBaseName.set('bootiful-cas-client')
-    archiveVersion.set('1.4.0')
+    archiveVersion.set('1.4.1')
 }
 sourceCompatibility = 11
 targetCompatibility = 11

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         springBootVersion = '2.6.3'
-        casClientVersion = '3.6.3'
+        casClientVersion = '3.6.4'
         jaxbApiVersion ='2.3.1'
         jaxbRuntimeVersion ='2.3.3'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ buildscript {
     ext {
         springBootVersion = '2.6.3'
         casClientVersion = '3.6.3'
+        jaxbApiVersion ='2.3.1'
+        jaxbRuntimeVersion ='2.3.3'
     }
     repositories {
         gradlePluginPortal()
@@ -41,6 +43,8 @@ dependencies {
     implementation('org.codehaus.groovy:groovy')
     implementation("org.webjars:bootstrap:3.3.4")
     implementation("org.jasig.cas.client:cas-client-support-springboot:${casClientVersion}")
+    implementation("javax.xml.bind:jaxb-api:${jaxbApiVersion}")
+    implementation("org.glassfish.jaxb:jaxb-runtime:${jaxbRuntimeVersion}")
 }
 
 bootBuildImage {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.6.1'
+        springBootVersion = '2.6.3'
         casClientVersion = '3.6.3'
     }
     repositories {
@@ -23,8 +23,8 @@ dependencyManagement {
 }
 
 jar {
-    baseName = 'bootiful-cas-client'
-    version = '1.4.0'
+    archiveBaseName.set('bootiful-cas-client')
+    archiveVersion.set('1.4.0')
 }
 sourceCompatibility = 11
 targetCompatibility = 11
@@ -37,6 +37,7 @@ repositories {
 dependencies {
     implementation('org.springframework.boot:spring-boot-starter-thymeleaf')
     implementation('org.springframework.boot:spring-boot-starter-web')
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation('org.codehaus.groovy:groovy')
     implementation("org.webjars:bootstrap:3.3.4")
     implementation("org.jasig.cas.client:cas-client-support-springboot:${casClientVersion}")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright Â© 2015-2021 the original authors.
+# Copyright © 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
-#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
-#         * compound commands having a testable exit status, especially Â«caseÂ»;
-#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
+#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
+#         * compound commands having a testable exit status, especially «case»;
+#         * various built-in commands including «command», «set», and «ulimit».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
This updates gradle version, updates spring boot and adds the actuator starter so the client can be shutdown via shutdown actuator (if it is started with options that enable the actuator). 